### PR TITLE
Added Dockerfile and entrypoint.sh to build a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:bookworm AS build
+WORKDIR /app
+COPY . .
+RUN go mod download \
+    && go build -tags=lmdb -ldflags "-X main.version=$(git describe --tags --always)" -o chronicle . \
+    && go clean -modcache
+
+FROM golang:bookworm
+COPY --from=build /app /app
+
+
+WORKDIR /app
+ENV RELAY_NAME="Cronicle Relay"
+ENV RELAY_DESCRIPTION="Nostr Personal Relay"
+ENV RELAY_PORT="3334"
+ENV DB_PATH="db/"
+ENV REFRESH_INTERVAL=24
+ENV MIN_FOLLOWERS=3
+ENV FETCH_SYNC="FALSE"
+VOLUME ["/app/db"]
+EXPOSE 3334
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Define the output file
+OUTPUT_FILE=".env"
+
+# Define the required environment variables
+REQUIRED_VARS=("OWNER_PUBKEY")
+
+# Define the all environment variables
+ALL_VARS=("OWNER_PUBKEY" "RELAY_NAME" "RELAY_DESCRIPTION" "RELAY_URL" "RELAY_ICON" "RELAY_CONTACT" "DB_PATH" "REFRESH_INTERVAL" "MIN_FOLLOWERS" "FETCH_SYNC" "POW_WHITELIST" "POW_DM_WHITELIST")
+
+# Check if all required environment variables are set
+for var in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!var}" ]; then
+    echo "Error: Environment variable $var is not set."
+    exit 1
+  fi
+done
+
+#Recreate conf file
+truncate -s 0 $OUTPUT_FILE
+
+# Write environment variables to the output file
+for var in "${ALL_VARS[@]}"; do
+  echo "$var=`printenv ${var}`" >> "$OUTPUT_FILE"
+done
+
+./chronicle


### PR DESCRIPTION
The docker image generated fetch all ENV from docker end generate .env file

Here an example of startup from command line

docker run --name chronicle -it --rm -p 3334:3334 -e OWNER_PUBKEY=dc1be7fdba0c8a1bf9065cdee45c948d574e780f74894251e9c95d16432655b9 dtonon/chronicle:latest

here a stack example
services:
  chronicle:
    image: dtonon/chronicle:latest
    volumes:
      - db:/app/db
    ports:
      - 3334:3334/tcp
    environment:
        OWNER_PUBKEY: "dc1be7fdba0c8a1bf9065cdee45c948d574e780f74894251e9c95d16432655b9"
        RELAY_NAME: "chronicle.url.io"
        RELAY_DESCRIPTION: "My Chronicle Relay"
        RELAY_URL: "chronicle.url.io"
        RELAY_CONTACT: "Daniele"
        FETCH_SYNC: "TRUE"
        MIN_FOLLOWERS: 2
        DB_PATH: "/app/db"
    restart: always

volumes:
    db: